### PR TITLE
Replace Steam Identifier in Bug Reports with Discord Name

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,11 +16,11 @@ body:
     validations:
       required: true
   - type: input
-    id: playerid
+    id: reporter
     attributes:
-      label: Discord Name
-      description: What is your Discord Name?
-      placeholder: BenIsCool#1234
+      label: Reporter
+      description: Who is reporting this? Please include discord name.
+      placeholder: John (John#0001)
     validations:
       required: true          
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,9 +18,9 @@ body:
   - type: input
     id: playerid
     attributes:
-      label: Player Identification
-      description: What is your steam profile?
-      placeholder: steam:123456789abcde
+      label: Discord Name
+      description: What is your Discord Name?
+      placeholder: BenIsCool#1234
     validations:
       required: true          
   - type: textarea


### PR DESCRIPTION
Player Identification changed to Reported to sync with the Assets Tracker.
Instead of asking for Steam ID, it now asks for Discord Name.